### PR TITLE
Adding a first analytics page migration

### DIFF
--- a/app/controllers/analytics/analytics.ctrl.js
+++ b/app/controllers/analytics/analytics.ctrl.js
@@ -1,0 +1,40 @@
+var express = require('express'),
+    cfg = require('../../../config/config'),
+    apiCfg = require('../../models/gbifdata/apiConfig'),
+    Country = require('../../models/gbifdata/gbifdata').Country,
+    router = express.Router();
+
+module.exports = function (app) {
+    app.use('/analytics', router);
+};
+
+router.get('/global', function(req, res, next) {
+    renderPage(req, res, next, 'global');
+});
+
+router.get('/country/:country/about', function(req, res, next) {
+    //TODO: make sure iso country exists
+    renderPage(req, res, next, 'country/' + req.params.country + '/about', req.params.country, true);
+});
+
+router.get('/country/:country/published', function(req, res, next) {
+    //TODO: make sure publishing country exists in GBIF
+    renderPage(req, res, next, 'country/' + req.params.country + '/publishedBy', req.params.country, false);
+});
+
+
+function renderPage(req, res, next, path, country, about) {
+    try {
+        res.render('pages/analytics/analytics', {
+            country: country,
+            about: about,
+            thumbBase: apiCfg.image.url + "fit-in/300x250/http://" + cfg.analyticsImg + path + "/figure/",
+            imgBase: apiCfg.image.url + "http://" + cfg.analyticsImg + path + "/figure/",
+            _meta: {
+                title: 'Data Trends'
+            }
+        });
+    } catch(e) {
+        next(e);
+    }
+}

--- a/app/controllers/analytics/analyticsFaq.ctrl.js
+++ b/app/controllers/analytics/analyticsFaq.ctrl.js
@@ -1,0 +1,18 @@
+var express = require('express'),
+    router = express.Router();
+
+module.exports = function (app) {
+    app.use('/analytics', router);
+};
+
+router.get('/faq', function(req, res, next) {
+    renderPage(req, res, next);
+});
+
+function renderPage(req, res, next) {
+    try {
+        res.render('pages/analytics/faq', {});
+    } catch(e) {
+        next(e);
+    }
+}

--- a/app/models/gbifdata/apiConfig.js
+++ b/app/models/gbifdata/apiConfig.js
@@ -18,6 +18,9 @@ var apiConfig = {
     datasetSearch: {
         url: baseUrl + 'dataset/search/'
     },
+    image: {
+        url: baseUrl + 'image/unsafe/'
+    },
     installation: {
         url: baseUrl + 'installation/'
     },

--- a/app/views/pages/analytics/analytics.nunjucks
+++ b/app/views/pages/analytics/analytics.nunjucks
@@ -1,0 +1,343 @@
+{% extends ".nunjucks ./../shared/layout/html/html.nunjucks" %}
+
+{% block page %}
+
+<!--
+TODO: figure out how to best execute custom JS on specific pages
+-->
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+        var lightbox = new Lightbox();
+        lightbox.load();
+    }, false);
+</script>
+
+<article class="wrapper-horizontal-stripes">
+    <div class="horizontal-stripe article-header white-background">
+        <div class="container">
+            <div class="row">
+                <header class="col-xs-12 text-center">
+                    <nav class="article-header__category article-header__category--deep">
+                        <span class="article-header__category__upper">Analytics</span>
+                        <span class="article-header__category__lower">{% if country %}{$ __('country.'+country) $}{% else %}Global{% endif %}</span>
+                    </nav>
+                    <h1>
+                        {% if country %}
+                            {$ __('country.'+country) $}
+                            {% if about%}data{% else %}publishing{% endif %}
+                            trends
+                        {% else %}
+                            Global data trends
+                        {% endif %}
+                     </h1>
+                    <div class="article-header__intro">
+                        {% if country and about %}
+                            <p>Change over time in data about species from {$ __('country.'+country) $} available from GBIF.org.</p>
+                        {% elif country %}
+                            <p>Change over time in the data published by institutions within {$ __('country.'+country) $} available from GBIF.org</p>
+                        {% else %}
+                            <p>Trends in data availability on the GBIF network, 2008 to 2016</p>
+                        {% endif %}
+                    </div>
+                </header>
+            </div>
+        </div>
+    </div>
+
+    <section id="species-occurrence" class="horizontal-stripe white-background">
+        <div class="container--normal">
+                <h3>Number of occurrence records</h3>
+                <p>These charts illustrate the change in availability of the species occurrence records over time.</p>
+
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4>Records by kingdom</h4>
+                        <p>The number of available records categorized by kingdom.  "Unknown" includes records with taxonomic information that cannot be linked to available taxonomic checklists.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Records for Animalia</h4>
+                        <p>The number of animal records categorized by the basis of record. "Unknown" includes records without defined basis of record or with an unrecognised value for basis of record.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Records for Plantae</h4>
+                        <p>The number of plant records categorized by the basis of record. "Unknown" includes records without defined basis of record or with an unrecognised value for basis of record.</p>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img class="jslghtbx-thmb" src="{$ thumbBase $}occ_animaliaBoR.png" data-jslghtbx="{$ imgBase $}occ_animaliaBoR.png" class="img-thumbnail">
+                    </div>
+                    <div class="col-xs-4">
+                        <img class="jslghtbx-thmb" src="{$ thumbBase $}occ_plantaeBoR.png" data-jslghtbx="{$ imgBase $}occ_plantaeBoR.png"  class="img-thumbnail">
+                    </div>
+                    <div class="col-xs-4">
+                        <img class="jslghtbx-thmb" src="{$ thumbBase $}occ_kingdom.png" data-jslghtbx="{$ imgBase $}occ_kingdom.png"  class="img-thumbnail">
+                    </div>
+                </div>
+            </div>
+    </section>
+
+    <section id="species-occurrence2" class="horizontal-stripe white-background">
+        <div class="container--normal article-auxiliary">
+                <h3>Species counts</h3>
+                <p>These charts illustrate the change in the number of species for which occurrence records are available.</p>
+
+                <div class="bs-callout bs-callout-default">
+                    <h4>Definition</h4>
+                    <p>Species counts are based on the number of binomial scientific names for which GBIF has received data records, organised as far as possible using synonyms recorded in key databases such as the Catalogue of Life. Since many names are not yet included in these databases, some proportion of these names will be unrecognised synonyms and do not represent valid species.  Therefore these counts can be used as an indication of richness only, and do not represent true species counts. All data have been processed using the same, most recent, version of the common GBIF backbone taxonomy, and comparisons over time are therefore realistic.</p>
+                </div>
+
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4>Species count by kingdom</h4>
+                        <p>The number of species with available occurrence records, categorized by kingdom.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Species count for specimen records</h4>
+                        <p>The number of species associated with specimen records.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Species count for observation records</h4>
+                        <p>The number of species associated with observation records.</p>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}spe_kingdom.png" data-jslghtbx="{$ imgBase $}spe_kingdom.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}spe_kingdom_specimen.png" data-jslghtbx="{$ imgBase $}spe_kingdom_specimen.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}spe_kingdom_observation.png" data-jslghtbx="{$ imgBase $}spe_kingdom_observation.png"  />
+                    </div>
+                </div>
+            </div>
+
+    </section>
+    <section id="occurrence-temporal" class="horizontal-stripe white-background">
+        <div class="container--normal article-auxiliary">
+                <h3>Time and seasonality</h3>
+                <p>These charts illustrate changes in the spread of records by year of occurrence and by day of year, indicating the extent of possible bias towards more recent periods or particular seasons. Snapshots are provided for approximately 3-year intervals to show changes in spread.</p>
+                <div class="bs-callout bs-callout-default">
+                    <h4>Definition</h4>
+                    <p>Species counts are based on the number of binomial scientific names for which GBIF has received data records, organised as far as possible using synonyms recorded in key databases such as the Catalogue of Life. Since many names are not yet included in these databases, some proportion of these names will be unrecognised synonyms and do not represent valid species.  Therefore these counts can be used as an indication of richness only, and do not represent true species counts. All data have been processed using the same, most recent, version of the common GBIF backbone taxonomy, and comparisons over time are therefore realistic.</p>
+                </div>
+
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4>Records by year of occurrence</h4>
+                        <p>The number of occurrence records available for each year since 1950.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Species by year of occurrence</h4>
+                        <p>The number of species (see above) for which records are available for each year since 1950.</p>
+                    </div>
+                    <div class="col-xs-4">
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_yearCollected.png" data-jslghtbx="{$ imgBase $}occ_yearCollected.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}spe_yearCollected.png" data-jslghtbx="{$ imgBase $}spe_yearCollected.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                    </div>
+                </div>
+
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4>Records by day of year</h4>
+                        <p>The number of occurrence records available for each day of the year.</p>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4>Species by day of year</h4>
+                        <p>The number of species (see above) for which records are available for each day of the year.</p>
+                    </div>
+                    <div class="col-xs-4">
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_dayCollected.png" data-jslghtbx="{$ imgBase $}occ_dayCollected.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}spe_dayCollected.png" data-jslghtbx="{$ imgBase $}spe_dayCollected.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                    </div>
+                </div>
+
+                <div class="bs-callout bs-callout-default">
+                    <h4>Note</h4>
+                    <p>These charts may reveal patterns that represent biases in data collection (seasonality, public holidays) or potential issues in data management (disproportionate numbers of records shown for the first or last days in the year or each month or week).
+                        Such issues may arise at various stages in data processing and require further investigation.</p>
+                    <p>By generating these charts <a href="http://dev.gbif.org/issues/browse/POR-2120">an issue</a> was detected in the GBIF processing which contributes to the spike seen on the first day of the year in several charts and will be addressed.</p>
+                </div>
+            </div>
+
+    </section>
+    <section id="occurrence-completeness" class="horizontal-stripe white-background">
+        <div class="container--normal article-auxiliary">
+                <h3>Completeness and precision</h3>
+                <p>These charts illustrate changes in the completeness (see below) of available records and in the precision of these records with respect to time, geography and taxonomy.</p>
+
+                <div class="bs-callout bs-callout-default">
+                    <h4>Definition</h4>
+                    <p>A record is here defined to be complete if it includes an identification at least to species rank, valid coordinates, a full date of occurrence and a given basis of record (e.g. Observation, specimen etc).</p>
+                </div>
+
+                <h3>Completeness</h3>
+                <p>These charts illustrate changes in the number of records considered complete according to the definition above.  Separate charts separately show the same information for specimen records and for observation records. Subsequent charts illustrate the component elements that affect the number of complete records.</p>
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4 class="text-center">All records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Specimen records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Observation records</h4>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete.png" data-jslghtbx="{$ imgBase $}occ_complete.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_specimen.png" data-jslghtbx="{$ imgBase $}occ_complete_specimen.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_observation.png" data-jslghtbx="{$ imgBase $}occ_complete_observation.png"  />
+                    </div>
+                </div>
+
+                <h3>Taxonomic precision</h3>
+                <p>These charts illustrate changes in the number of available records which include an identification at least to the species rank.  The numbers of records identified to an infraspecific rank or to a genus are also shown.</p>
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4 class="text-center">All records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Specimen records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Observation records</h4>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_kingdom.png" data-jslghtbx="{$ imgBase $}occ_complete_kingdom.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_kingdom_specimen.png" data-jslghtbx="{$ imgBase $}occ_complete_kingdom_specimen.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_kingdom_observation.png" data-jslghtbx="{$ imgBase $}occ_complete_kingdom_observation.png"  />
+                    </div>
+                </div>
+
+                <h3>Geographic precision</h3>
+                <p>These charts illustrate changes in the number of available records which include coordinates for which no known issues have been detected.  For records without accepted valid coordinates, these charts also show the number of records for which the country of occurrence is known.</p>
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4 class="text-center">All records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Specimen records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Observation records</h4>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_geo.png" data-jslghtbx="{$ imgBase $}occ_complete_geo.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_geo_specimen.png" data-jslghtbx="{$ imgBase $}occ_complete_geo_specimen.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_geo_observation.png" data-jslghtbx="{$ imgBase $}occ_complete_geo_observation.png"  />
+                    </div>
+                </div>
+
+                <h3>Temporal precision</h3>
+                <p>These charts illustrate changes in the number of available records which include a complete date including year, month and day.  The numbers of records including only the month and year or only the year are also shown.</p>
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4 class="text-center">All records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Specimen records</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">Observation records</h4>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_date.png" data-jslghtbx="{$ imgBase $}occ_complete_date.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_date_specimen.png" data-jslghtbx="{$ imgBase $}occ_complete_date_specimen.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_complete_date_observation.png" data-jslghtbx="{$ imgBase $}occ_complete_date_observation.png"  />
+                    </div>
+                </div>
+            </div>
+
+    </section>
+    <section id="occurrence-cells" class="horizontal-stripe white-background">
+        <div class="container--normal article-auxiliary">
+                <h3>Geographic coverage for recorded species</h3>
+                <p>These charts illustrate the change in the number of species for which occurrence records are available.</p>
+                <div class="balanced-row">
+                    <div class="col-xs-4">
+                        <h4 class="text-center">1.0 degree</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">0.5 degree</h4>
+                    </div>
+                    <div class="col-xs-4">
+                        <h4 class="text-center">0.1 degree</h4>
+                    </div>
+                </div>
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_cells_one_deg.png" data-jslghtbx="{$ imgBase $}occ_cells_one_deg.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_cells_half_deg.png" data-jslghtbx="{$ imgBase $}occ_cells_half_deg.png"  />
+                    </div>
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_cells_point_one_deg.png" data-jslghtbx="{$ imgBase $}occ_cells_point_one_deg.png"  />
+                    </div>
+                </div>
+            </div>
+
+    </section>
+    <section id="occurrence-repatriation" class="horizontal-stripe white-background">
+        <div class="container--normal article-auxiliary">
+                <h3>Data sharing with country of origin</h3>
+                {% if country and about %}
+                    <p>This chart shows the number of records about biodiversity occurring in {$ __('country.'+country) $}, with separate colours for records published from within {$ __('country.'+country) $}, and those shared by publishers from other countries.</p>
+                {% elif country %}
+                    <p>This chart shows the number of records shared by publishers within {$ __('country.'+country) $} over time, with separate colours for records about species occurring in {$ __('country.'+country) $} and those occurring in other countries.</p>
+                {% else %}
+                    <p>This chart shows the total number of records published through GBIF over time, with separate colours for records published from within the country where the species occurred, and those shared by publishers from other countries.</p>
+                {% endif %}
+                <div class="balanced-row row-chart">
+                    <div class="col-xs-4">
+                        <img src="{$ thumbBase $}occ_repatriation.png" data-jslghtbx="{$ imgBase $}occ_repatriation.png"  />
+                    </div>
+                </div>
+            </div>
+    </section>
+
+</article>
+
+{% endblock %}

--- a/app/views/pages/analytics/analytics.styl
+++ b/app/views/pages/analytics/analytics.styl
@@ -1,0 +1,31 @@
+.row-chart img {
+    border: 1px solid #ddd;
+}
+.bs-callout {
+    background-color: #f7f9fa;
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #eee;
+    border-left-width: 5px;
+    border-right-width: 0;
+    border-radius: 3px;
+}
+.bs-callout h4 {
+    margin-top: 0;
+    margin-bottom: 5px;
+}
+.bs-callout p:last-child {
+    margin-bottom: 0;
+}
+.bs-callout code {
+    border-radius: 3px;
+}
+.bs-callout+.bs-callout {
+    margin-top: -5px;
+}
+.bs-callout-default {
+    border-left-color: #777;
+}
+.bs-callout-default h4 {
+    color: #777;
+}

--- a/app/views/pages/analytics/faq.nunjucks
+++ b/app/views/pages/analytics/faq.nunjucks
@@ -1,0 +1,127 @@
+{% extends ".nunjucks ./../shared/layout/html/html.nunjucks" %}
+
+{% block page %}
+    <article class="wrapper-horizontal-stripes">
+        <div class="horizontal-stripe article-header white-background">
+            <div class="container">
+                <div class="row">
+                    <header class="col-xs-12 text-center">
+                        <nav class="article-header__category article-header__category--deep">
+                            <span class="article-header__category__upper">Analytics</span>
+                            <span class="article-header__category__lower">FAQ</span>
+                        </nav>
+                        <h1>Data trends - frequently asked questions</h1>
+                        <div class="article-header__intro">
+                            <p>Please <a href="mailto:helpdesk@gbif.org">contact us</a> for question about the data trends.</p>
+                        </div>
+                    </header>
+                </div>
+            </div>
+
+            <div class="container-fluid container--prose">
+                <div class="body-text">
+
+                    <h3>Context</h3>
+                    <p>
+                        <dl class="faq">
+                            <dt><a href="#context1" id="context1">Who is producing these charts and why?</a></dt>
+                            <dd>The GBIF Secretariat is producing information on data mobilization trends observed on the GBIF network.
+                                Showing trends on the data mobilized by the GBIF network can help with planning data mobilization efforts,
+                                showing the results of previous investments in digitization or data mobilization, or in highlighting issues
+                                to be targeted to improve the fitness-for-use of the data.</dd>
+
+                            <dt><a href="#context2" id="context2">Are these reports available as a download?</a></dt>
+                            <dd>Not currently, but we plan to add this feature in 2015. If you are interested in being able to download these reports,
+                                please use the feedback button on the side of this page to explain how you would wish to see this feature implemented.</dd>
+
+                            <dt><a href="#context3" id="context3">Can I reproduce these charts in my national reports?</a></dt>
+                            <dd>Yes, however we encourage that they be reviewed before doing so.</dd>
+
+                            <dt><a href="#context4" id="context4">How often will the charts be updated?</a></dt>
+                            <dd>The charts show data trending from the end of 2007 until recent weeks and will be recalculated
+                                periodically; approximately quarterly.</dd>
+
+                            <dt><a href="#context5" id="context5">How can I contribute to this work?</a></dt>
+                            <dd>This project is being developed openly on the <a href="https://github.com/gbif/analytics">GitHub project site</a>.
+                                While some data preparation stages require access to the GBIF index and Hadoop infrastructure, other
+                                stages run using R and can be developed remotely.  Please <a href="mailto:dev@gbif.org">contact us</a>
+                                if you would like to contribute to the work.</dd>
+                        </dl>
+                    </p>
+
+                    <h3>Understanding the trends and improving the charts</h3>
+                    <p>
+                        <dl class="faq">
+                            <dt><a href="#imp1" id="imp1">How have these trends been produced?</a></dt>
+                            <dd>The project is documented on the <a href="https://github.com/gbif/analytics">GitHub project site</a>.
+                                Approximately 4 historical views per year of the GBIF index were restored (totalling approximately 8
+                                Billion records in May 2014), and the raw data were processed to the <strong>latest quality control and taxonomic backbone</strong>.
+                                Various scripts were then used to digest the records into smaller views which are then processed in R to produce the charts.
+                            </dd>
+
+                            <dt><a href="#imp2" id="imp2">How do they take into account changes in the GBIF taxonomic backbone over time?</a></dt>
+                            <dd>All data are processed to the latest GBIF backbone taxonomy, to ensure that species counts are comparable over time.</dd>
+
+                            <dt><a href="#imp3" id="imp3">In some charts I can see that the amount of mobilized data sometimes goes down before going up again. Why might that be?</a></dt>
+                            <dd>This is due to the removal of data sets from GBIF. This might occur if a publisher wishes to remove their data, but is often
+                                due to the removal of datasets that were inadvertently published twice (duplicate datasets).</dd>
+
+                            <dt><a href="#imp4" id="imp4">I can see strange peaks in the charts showing trends in the temporality of the data. What might be the cause of this?</a></dt>
+                            <dd>The charts may reveal patterns that represent biases in data collection (seasonality, public holidays) or potential issues in data management
+                                (disproportionate numbers of records shown for the first or last days in the year or each month or week). Such issues may arise at various
+                                stages in data processing and require further investigation.</dd>
+
+                            <dt><a href="#imp5" id="imp4">I have suggestions to improve the clarity of the charts included here - what should I do?</a></dt>
+                            <dd>Please use the feedback button on the side of the page to log any suggestions.</dd>
+
+                            <dt><a href="#imp6" id="imp6">Why are these charts presented as static images and not something more dynamic?</a></dt>
+                            <dd>This is a first iteration of work.  Future versions could be more interactive, although one has to consider if a
+                                PDF view or simple images for (e.g.) annual reports are required.  As an open project, anyone with interest in improving
+                                the data visualization is welcome to get involved.  Please <a href="mailto:dev@gbif.org">contact us</a>.</dd>
+
+                            <dt><a href="#imp7" id="imp7">How did you select the colours used in these charts and can we improve them?</a></dt>
+                            <dd>The colour palettes come from <a href="http://colorbrewer2.org/">colorbrewer2.org</a> and an attempt was made to select
+                                colours that would be colour-blind safe.  It is difficult to find suitable colour palettes that work on all charts
+                                (e.g. global and country specific) and input would be greatly appreciated to help improve these.</dd>
+
+                            <dt><a href="#imp8" id="imp8">Which technologies were involved in this work?</a></dt>
+                            <dd>The original unprocessed data resides in Hadoop.  Hive is used for the SQL processing on the Hadoop data using custom
+                                UDFs wrapping the GBIF core processing libraries (Java).  Hive is used to digest the data into CSV tables.  All other processing is in R.</dd>
+                        </dl>
+                    </p>
+
+                    <h3>How to get involved</h3>
+                    <p>
+                        <dl class="faq">
+                            <dt><a href="#inv1" id="inv1">What can I do to improve the completeness of records available through GBIF?</a></dt>
+                            <dd>A complete record is here defined as having species identification, valid coordinates and the full date of
+                                collection or observation. The charts show that some records published to GBIF are incomplete. There can be
+                                different reasons for this, which include deliberately excluding coordinates for sensitive data, or the full
+                                date of collection not being available for some historic collections. However, for many datasets, the completeness
+                                of records could be improved by working with the data publisher concerned. All GBIF Nodes are encouraged to consider
+                                how they can work with the data publishers in their networks to improve the completeness of the records, which will
+                                contribute to making these data fit for a broader range of uses.</dd>
+
+                            <dt><a href="#inv2" id="inv2">I have suggestions for other interesting charts that I would like to see on GBIF.org. Can I request more charts?</a></dt>
+                            <dd>In future GBIF work programmes, it may be possible to extend this work further to include other interesting trends around data mobilization in GBIF.
+                                Please use the feedback button to provide any additional ideas or comments on the current charts, <a href="#inv1">or consider contributing to the project</a>.</dd>
+
+                            <dt><a href="#inv3" id="inv3">What would it take for me to produce these charts myself in a different style or language?</a></dt>
+                            <dd>The scripts used for this work are maintained in the <a href="https://github.com/gbif/analytics">GitHub project site</a>.
+                                GBIF can provide the underlying digested data in the form of a collection of CSV files which can be used in various applications
+                                to produce the charts.  For those wishing to do far more detailed analysis than GBIF is able to do globally, the processed source
+                                records can be provided for subsets of the data (e.g. all records for Spain). Please note that the Secretariat has limited resources
+                                but will do all they can to support others wishing to further the analysis.  Please also note that the volumes of data can be very large -
+                                the data covers approximately 8 Billion records (May 2014)</dd>
+
+                            <dt><a href="#inv4" id="inv4">How do I provide feedback?</a></dt>
+                            <dd>Please use the feedback button on the side of each page or <a href="mailto:helpdesk@gbif.org">contact us</a> by mail.</dd>
+
+                        </dl>
+                    </p>
+                </div>
+            </div>
+
+        </div>
+    </article>
+{% endblock %}

--- a/app/views/shared/layout/html/angular/env.constants.jsTemplate
+++ b/app/views/shared/layout/html/angular/env.constants.jsTemplate
@@ -1,13 +1,14 @@
 (function () {
     'use strict';
     var angular = require('angular');
-    
+
     angular
         .module('portal')
         .constant('env', {
             dataApi: '{{DATA_URL}}', //e.g //api.gbif.org/v1/
             tileApi: '{{TILE_URL}}', //e.g. //cdn.gbif.org/v1/map/density/tile.png
-            cmsApi: '{{CMS_URL}}' //e.g. //cms.gbif-dev.org/api/
+            cmsApi: '{{CMS_URL}}',   //e.g. //cms.gbif-dev.org/api/
+            analyticsImg: '{{ANALYTICS_IMG}}' //e.g. //cms.gbif-dev.org/sites/default/files/gbif_analytics/
         })
         .constant('suggestEndpoints', {
             recordedBy: '{{DATA_URL}}occurrence/search/recordedBy',

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "leaflet": "^0.7.7",
     "leaflet.markercluster": "~0.5.0",
-    "nouislider": "~8.5.1"
+    "nouislider": "~8.5.1",
+    "jsonlylightbox": "~0.5.0"
   }
 }

--- a/config/config.js
+++ b/config/config.js
@@ -7,6 +7,7 @@ var path = require('path'),
     dataApi = yargs.dataapi,
     tileApi = yargs.tileapi,
     cmsApi = yargs.cmsapi,
+    analyticsImg = yargs.analyticsImg,
     ghpw = yargs.ghpw;
 
 var config = {
@@ -21,7 +22,8 @@ var config = {
         githubPassword: ghpw,
         dataApi: dataApi || 'http://api.gbif.org/v1/',
         tileApi: tileApi || 'http://api.gbif.org/v1/map/density/tile.png',
-        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/'
+        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/',
+        analyticsImg: analyticsImg || 'cms.gbif-dev.org/sites/default/files/gbif_analytics/'
     },
     dev: {
         env: env,
@@ -34,7 +36,8 @@ var config = {
         githubPassword: ghpw,
         dataApi: dataApi || 'http://api.gbif.org/v1/',
         tileApi: tileApi || 'http://api.gbif.org/v1/map/density/tile.png',
-        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/'
+        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/',
+        analyticsImg: analyticsImg || 'cms.gbif-dev.org/sites/default/files/gbif_analytics/'
     },
     uat: {
         env: env,
@@ -47,7 +50,8 @@ var config = {
         githubPassword: ghpw,
         dataApi: dataApi || 'http://api.gbif.org/v1/',
         tileApi: tileApi || 'http://api.gbif.org/v1/map/density/tile.png',
-        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/'
+        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/',
+        analyticsImg: analyticsImg || 'cms.gbif-dev.org/sites/default/files/gbif_analytics/'
     },
     prod: {
         env: env,
@@ -60,7 +64,8 @@ var config = {
         githubPassword: ghpw,
         dataApi: dataApi || 'http://api.gbif.org/v1/',
         tileApi: tileApi || 'http://cdn.gbif.org/v1/map/density/tile.png',
-        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/'
+        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/',
+        analyticsImg: analyticsImg || 'cms.gbif-dev.org/sites/default/files/gbif_analytics/'
     },
     test: {
         env: env,
@@ -73,7 +78,8 @@ var config = {
         githubPassword: ghpw,
         dataApi: dataApi || 'http://api.gbif-dev.org/v1/',
         tileApi: tileApi || 'http://api.gbif-dev.org/v1/map/density/tile.png',
-        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/'
+        cmsApi: cmsApi || 'http://cms.gbif-dev.org/api/',
+        analyticsImg: analyticsImg || 'cms.gbif-dev.org/sites/default/files/gbif_analytics/'
     }
 };
 

--- a/gulp/tasks/envConstants.js
+++ b/gulp/tasks/envConstants.js
@@ -10,12 +10,14 @@ var gulp = require('gulp'),
 gulp.task('env-constants', [], function () {
     var DATA_URL = configEnv.dataApi,
         TILE_URL = configEnv.tileApi,
-        CMS_URL = configEnv.cmsApi;
+        CMS_URL = configEnv.cmsApi,
+        ANALYTICS_IMG = configEnv.analyticsImg;
 
     return gulp.src(config.envConstants.path)
         .pipe(g.replace('{{DATA_URL}}', DATA_URL))
         .pipe(g.replace('{{TILE_URL}}', TILE_URL))
         .pipe(g.replace('{{CMS_URL}}', CMS_URL))
+        .pipe(g.replace('{{ANALYTICS_IMG}}', ANALYTICS_IMG))
         .pipe(g.rename(function (path) {
             path.extname = ".js"
         }))


### PR DESCRIPTION
This should add a first working version for the analytics pages incl the faq, global data trends, trends about and published by a country.

There are still some todos like verifying the country or participant actually exists.
Also whether angular should be used and where to best run the lightbox init (temporarily now in nunjucks)

Adds a new analyticsImg property to the configs and extends the apiConfig by the image cache