### PR TITLE
Include typo example in feedback template for content reports

### DIFF
--- a/locales/server/en.json
+++ b/locales/server/en.json
@@ -2414,7 +2414,7 @@
     },
     "content": {
       "title": "Content",
-      "example": "Such as: That species doesn’t exist. That location seems suspect. The new URL for that organization is...",
+      "example": "Such as: That page contains a typo. That species doesn’t exist. That location seems suspect. The new URL for that organization is...",
       "annotate": "This publisher has a website for handling feedback. We recommend using that",
       "contactPerMail": "Get in touch with the dataset contact"
     },


### PR DESCRIPTION
I find it useful to know that even typo corrections can be feedback. Initially I thought to include this into "bug" (because I know the difference between content written by publishers and content written by GBIF), but most users won't and "content" is more intuitive for a typo.