### PR TITLE
Update pre-download popup

### DIFF
--- a/app/views/pages/occurrence/download/occurrenceDownload.html
+++ b/app/views/pages/occurrence/download/occurrenceDownload.html
@@ -256,7 +256,7 @@
         <div class="gb-modal-body" id="modal-body">
             <div class="gb-modal-body__content horizontal-stripe white-background">
                 <p>
-                    It is imporant for crediting data publishers and for reputation of the data users to cite data correctly. You will receive the recommended GBIF citation, including DOI, together with your requested data. By citing data correctly you will comply to best practice in transparent science.
+                    It is important for crediting data publishers and for reputation of the data users to cite data correctly. You will receive the recommended GBIF citation, including DOI, together with your requested data. By citing data correctly you will comply to best practice in transparent science.
                 </p>
                 <p>
                     Note that if you are analysing the data you will download, please consider placing the download DOI into your Materials and methods section.

--- a/app/views/pages/occurrence/download/occurrenceDownload.html
+++ b/app/views/pages/occurrence/download/occurrenceDownload.html
@@ -256,10 +256,10 @@
         <div class="gb-modal-body" id="modal-body">
             <div class="gb-modal-body__content horizontal-stripe white-background">
                 <p>
-                    It is important for crediting data publishers and for reputation of the data users to cite data correctly. You will receive the recommended GBIF citation, including DOI, together with your requested data. By citing data correctly you will comply to best practice in transparent science.
+                    To promote transparent science and credit data publishers it is important to cite data correctly. You can do so by including the <a href="https://www.gbif.org/citation-guidelines">recommended GBIF citation</a> in your work, which you will receive together with your requested data.
                 </p>
                 <p>
-                    Note that if you are analysing the data you will download, please consider placing the download DOI into your Materials and methods section.
+                    If you are analysing the data you will download, please consider referencing this citation in your Materials and methods section.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Hi, I noticed a typo (`imporant`) in the pre-download popup which users see when they download data. I've corrected it in 46d4b1e, but then worked to rephrase the whole text a bit in a985867:

Before:

> It is imporant for crediting data publishers and for reputation of the data users to cite data correctly. You will receive the recommended GBIF citation, including DOI, together with your requested data. By citing data correctly you will comply to best practice in transparent science.
> 
> Note that if you are analysing the data you will download, please consider placing the download DOI into your Materials and methods section.

After:

> To promote transparent science and credit data publishers it is important to cite data correctly. You can do so by including the [recommended GBIF citation](https://www.gbif.org/citation-guidelines) in your work, which you will receive together with your requested data.
> 
> If you are analysing the data you will download, please consider referencing this citation by including it in your Materials and methods section.

Rationale:

* Put transparent science first, credit data publishers second, which makes a bit more sense from the perspective of the data user. I dropped the "reputation of data user" as this is part of transparent science.
* Then lead directly to how you can do that: by including recommended GBIF citation in your work.
* And then where you'll be able to find that citation (in the download)
* In the last sentence I keep the focus on analysing data, but rephrased it to include a reference to the citation, and not the DOI. It's a bit confusing why you would need to cite elsewhere and only include the DOI here.
* I also linked to the citation-guidelines page for more info. You might change that to a) open this link in a new window so they user is not taken out of the download flow or b) remove it.
* I dropped the DOI mention from the text, as a recommended GBIF citation implies a DOI (it's very clearly indicated on https://www.gbif.org/citation-guidelines). If the user copy/pastes the recommended citation from his/her download the DOI should make it.
* The total text is shorter, which should increase the chance of people reading it. 😄 

Also, do we use `z` or `s` in analysing, digitising, etc.? Is it written somewhere which English you use for the website?