### PR TITLE
Update config.js serverProtocol to https for domains that use https

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -99,7 +99,7 @@ let config = {
             name: 'portal - dev'
         },
         port: port || 80,
-        serverProtocol: 'http:',
+        serverProtocol: 'https:',
         apidocs: apidocs,
         managementToolsSite: '//registry.gbif-dev.org/',
         dataApiV2: dataApiV2 || '//api.gbif-dev.org/v2/',
@@ -270,7 +270,7 @@ let config = {
             name: 'portal - uat'
         },
         port: port || 80,
-        serverProtocol: 'http:',
+        serverProtocol: 'https:',
         apidocs: apidocs,
         managementToolsSite: '//registry.gbif-uat.org/',
         dataApiV2: dataApiV2 || '//api.gbif-uat.org/v2/',
@@ -395,7 +395,7 @@ let config = {
             name: 'portal - staging'
         },
         port: port || 80,
-        serverProtocol: 'http:',
+        serverProtocol: 'https:',
         apidocs: apidocs,
         managementToolsSite: '//registry.gbif.org/',
         dataApiV2: dataApiV2 || '//api.gbif.org/v2/',
@@ -435,7 +435,7 @@ let config = {
             name: 'portal - prod'
         },
         port: port || 80,
-        serverProtocol: 'http:',
+        serverProtocol: 'https:',
         apidocs: apidocs,
         managementToolsSite: '//registry.gbif.org/',
         dataApiV2: dataApiV2 || '//api.gbif.org/v2/',
@@ -555,7 +555,7 @@ let config = {
             name: 'portal - test'
         },
         port: port || 3000,
-        serverProtocol: 'http:',
+        serverProtocol: 'https:',
         apidocs: apidocs,
         managementToolsSite: '//registry.gbif-uat.org/',
         dataApiV2: dataApiV2 || '//api.gbif.org/v2/',


### PR DESCRIPTION
All of the API documentation curl examples, for example at https://www.gbif.org/developer/occurrence#predicates, currently use http:// which is bad since credentials are transferred with the request and credentials should be secret. The generated example URLs are determined based on the serverProtocol as defined here. Only environments with a domain that includes https were changed, local which is http://localhost:3000 was left unchanged.