### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git*
+Dockerfile


### PR DESCRIPTION
Add a simple `.dockerignore` file to speedup image creation (no need to recreate the whole image if something in git changed) and reduce its size.