### PR TITLE
Update datasetKey.ctrl.js

### DIFF
--- a/app/controllers/dataset/key/datasetKey.ctrl.js
+++ b/app/controllers/dataset/key/datasetKey.ctrl.js
@@ -225,7 +225,7 @@ function getMetaSchema(dataset) {
           '@type': 'Place',
           'geo': {
               '@type': 'GeoShape',
-              'box': `${box.minLatitude} ${box.maxLatitude} ${box.minLongitude} ${box.maxLongitude}`
+              'box': `${box.minLatitude} ${box.minLongitude} ${box.maxLatitude} ${box.maxLongitude}`
           }
       };
     }


### PR DESCRIPTION
Fix schema.org json-ld box representation. 

According to https://schema.org/box, the bounding box should be listed as lower left, and upper right coordinate pairs (eg. `"box" : "south west north east"` - `"box": "27.01 -124.77 48.40 -114.04"` ). 
Example dataset - https://portal.edirepository.org/nis/mapbrowse?scope=knb-lter-sbc&identifier=74

From what I am seeing on the GBIF dataset landing pages, GBIF is writing the box coordinate pairs in the incorrect order in the schema.org json-ld. (eg. `"box": "south north west east"` - `"box": "24.476 25.006 -81.715 -80.379"`)
Example dataset - dx.doi.org/10.15468/buqg4u

This PR should fix the order.